### PR TITLE
Create no_ranged_combat

### DIFF
--- a/src/main/resources/data/even_more_origins/powers/no_ranged_combat
+++ b/src/main/resources/data/even_more_origins/powers/no_ranged_combat
@@ -1,0 +1,15 @@
+{
+  "type": "origins:prevent_item_use",
+  "item_condition": {
+    "type": "origins:and",
+    "conditions": [
+      {
+        "type": "origins:ingredient",
+        "ingredient": {
+          "tag": "even_more_origins:no_ranged"
+        },
+        "inverted": false
+      },
+    ]
+  }
+}


### PR DESCRIPTION
unable to use bows, crossbows, or tridents. Unfortunately include riptide tridents, see tags/items/no_ranged.json's comments if u can help with allowing the use of riptide tridents but not other tridents.